### PR TITLE
Add NFData instances

### DIFF
--- a/boolean-normal-forms.cabal
+++ b/boolean-normal-forms.cabal
@@ -43,7 +43,7 @@ library
   build-depends:       base        >=4.6   && <4.11,
                        containers  >=0.5   && <0.6,
                        cond        >=0.4.1 && <0.5,
-                       deepseq     >= 1.1.0.0
+                       deepseq     >=1.1.0.0 && <1.5
   default-language:    Haskell2010
   ghc-options:         -Wall
 

--- a/boolean-normal-forms.cabal
+++ b/boolean-normal-forms.cabal
@@ -42,7 +42,8 @@ library
                        ScopedTypeVariables
   build-depends:       base        >=4.6   && <4.11,
                        containers  >=0.5   && <0.6,
-                       cond        >=0.4.1 && <0.5
+                       cond        >=0.4.1 && <0.5,
+                       deepseq     >= 1.1.0.0
   default-language:    Haskell2010
   ghc-options:         -Wall
 

--- a/src/Data/Algebra/Boolean/CNF/List.hs
+++ b/src/Data/Algebra/Boolean/CNF/List.hs
@@ -24,6 +24,7 @@ import Data.Monoid
 import Data.Either (partitionEithers)
 import Data.Typeable (Typeable)
 import Data.Foldable (Foldable)
+import Control.DeepSeq (NFData(rnf))
 
 import Data.Algebra.Boolean.NormalForm
 import Data.Algebra.Boolean.Negable hiding (not)
@@ -92,3 +93,6 @@ instance NormalForm CNF where
           p (Left x)               = x
 
   fromFreeBoolean = fromNNF . toBooleanWith toNormalForm
+
+instance NFData a => NFData (CNF a) where
+  rnf (CNF xss) = rnf xss

--- a/src/Data/Algebra/Boolean/CNF/Set.hs
+++ b/src/Data/Algebra/Boolean/CNF/Set.hs
@@ -22,6 +22,7 @@ import Prelude hiding ((||),(&&),not,and,or,any,all)
 import Data.Monoid
 import Data.Typeable (Typeable)
 import Data.Foldable (Foldable)
+import Control.DeepSeq (NFData(rnf))
 
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -105,3 +106,6 @@ instance NormalForm CNF where
           p (Left x)                              = x
 
   fromFreeBoolean = fromNNF . toBooleanWith toNormalForm
+
+instance NFData a => NFData (CNF a) where
+  rnf (CNF xss) = rnf xss

--- a/src/Data/Algebra/Boolean/DNF/List.hs
+++ b/src/Data/Algebra/Boolean/DNF/List.hs
@@ -24,6 +24,7 @@ import Data.Monoid
 import Data.Either (partitionEithers)
 import Data.Typeable (Typeable)
 import Data.Foldable (Foldable)
+import Control.DeepSeq (NFData(rnf))
 
 import Data.Algebra.Boolean.NormalForm
 import Data.Algebra.Boolean.Negable hiding (not)
@@ -92,3 +93,6 @@ instance NormalForm DNF where
           q (Left x)               = x
 
   fromFreeBoolean = fromNNF . toBooleanWith toNormalForm
+
+instance NFData a => NFData (DNF a) where
+  rnf (DNF xss) = rnf xss

--- a/src/Data/Algebra/Boolean/DNF/Set.hs
+++ b/src/Data/Algebra/Boolean/DNF/Set.hs
@@ -22,6 +22,7 @@ import Prelude hiding ((||),(&&),not,and,or,any,all)
 import Data.Monoid
 import Data.Typeable (Typeable)
 import Data.Foldable (Foldable)
+import Control.DeepSeq (NFData(rnf))
 
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -105,3 +106,6 @@ instance NormalForm DNF where
           q (Left x)                              = x
 
   fromFreeBoolean = fromNNF . toBooleanWith toNormalForm
+
+instance NFData a => NFData (DNF a) where
+  rnf (DNF xss) = rnf xss

--- a/src/Data/Algebra/Boolean/FreeBoolean.hs
+++ b/src/Data/Algebra/Boolean/FreeBoolean.hs
@@ -17,6 +17,7 @@ module Data.Algebra.Boolean.FreeBoolean (
 
 import Data.Typeable (Typeable)
 import Data.Foldable (Foldable)
+import Control.DeepSeq (NFData(rnf))
 
 import Data.Algebra.Boolean.CoBoolean
 import Data.Algebra.Boolean.Negable hiding (not)
@@ -56,3 +57,10 @@ instance Boolean (FreeBoolean a) where
   (||)   = FBOr
   (&&)   = FBAnd
   not    = FBNot
+
+instance NFData a => NFData (FreeBoolean a) where
+  rnf (FBValue a) = rnf a
+  rnf (FBNot a) = rnf a
+  rnf (FBAnd a b) = rnf a `seq` rnf b
+  rnf (FBOr a b) = rnf a `seq` rnf b
+  rnf _ = ()

--- a/src/Data/Algebra/Boolean/FreeBoolean.hs
+++ b/src/Data/Algebra/Boolean/FreeBoolean.hs
@@ -60,7 +60,8 @@ instance Boolean (FreeBoolean a) where
 
 instance NFData a => NFData (FreeBoolean a) where
   rnf (FBValue a) = rnf a
-  rnf (FBNot a) = rnf a
+  rnf (FBNot a)   = rnf a
   rnf (FBAnd a b) = rnf a `seq` rnf b
-  rnf (FBOr a b) = rnf a `seq` rnf b
-  rnf _ = ()
+  rnf (FBOr a b)  = rnf a `seq` rnf b
+  rnf FBTrue      = ()
+  rnf FBFalse     = ()

--- a/src/Data/Algebra/Boolean/NNF/Set.hs
+++ b/src/Data/Algebra/Boolean/NNF/Set.hs
@@ -106,6 +106,7 @@ instance NormalForm NNF where
 
 instance NFData a => NFData (NNF a) where
   rnf (NNFValue a) = rnf a
-  rnf (NNFOr a) = rnf a
-  rnf (NNFAnd a) = rnf a
-  rnf _ = ()
+  rnf (NNFOr a)    = rnf a
+  rnf (NNFAnd a)   = rnf a
+  rnf NNFTrue      = ()
+  rnf NNFFalse     = ()

--- a/src/Data/Algebra/Boolean/NNF/Set.hs
+++ b/src/Data/Algebra/Boolean/NNF/Set.hs
@@ -27,6 +27,7 @@ import Data.Algebra.Boolean
 
 import Data.Typeable (Typeable)
 import Data.Foldable (Foldable)
+import Control.DeepSeq (NFData(rnf))
 
 -- | Boolean formula in Negation Normal Form
 --
@@ -102,3 +103,9 @@ instance NormalForm NNF where
   simplify f (NNFOr xs)    = orList $ map (simplify f) $ Set.toList xs
 
   fromFreeBoolean          = toBooleanWith toNormalForm
+
+instance NFData a => NFData (NNF a) where
+  rnf (NNFValue a) = rnf a
+  rnf (NNFOr a) = rnf a
+  rnf (NNFAnd a) = rnf a
+  rnf _ = ()

--- a/src/Data/Algebra/Boolean/NNF/Tree.hs
+++ b/src/Data/Algebra/Boolean/NNF/Tree.hs
@@ -26,6 +26,7 @@ import Data.Algebra.Boolean
 
 import Data.Typeable (Typeable)
 import Data.Foldable (Foldable)
+import Control.DeepSeq (NFData(rnf))
 
 -- | Boolean formula in Negation Normal Form
 --
@@ -93,3 +94,9 @@ instance NormalForm NNF where
   simplify f (NNFOr a b)   = nnfOr (simplify f a) (simplify f b)
 
   fromFreeBoolean          = toBooleanWith toNormalForm
+
+instance NFData a => NFData (NNF a) where
+  rnf (NNFValue a) = rnf a
+  rnf (NNFOr a b) = rnf a `seq` rnf b
+  rnf (NNFAnd a b) = rnf a `seq` rnf b
+  rnf _ = ()

--- a/src/Data/Algebra/Boolean/NNF/Tree.hs
+++ b/src/Data/Algebra/Boolean/NNF/Tree.hs
@@ -97,6 +97,7 @@ instance NormalForm NNF where
 
 instance NFData a => NFData (NNF a) where
   rnf (NNFValue a) = rnf a
-  rnf (NNFOr a b) = rnf a `seq` rnf b
+  rnf (NNFOr a b)  = rnf a `seq` rnf b
   rnf (NNFAnd a b) = rnf a `seq` rnf b
-  rnf _ = ()
+  rnf NNFTrue      = ()
+  rnf NNFFalse     = ()

--- a/src/Data/Algebra/Boolean/Negable.hs
+++ b/src/Data/Algebra/Boolean/Negable.hs
@@ -19,6 +19,7 @@ import Data.Algebra.Boolean.CoBoolean
 
 import Data.Monoid
 import Data.Typeable
+import Control.DeepSeq (NFData(rnf))
 
 import Prelude hiding (not)
 import qualified Prelude as P
@@ -37,6 +38,10 @@ instance CoBoolean (Neg a) where
 instance CoBoolean1 Neg where
   toBooleanWith f (Pos x) = f x
   toBooleanWith f (Neg x) = B.not $ f x
+
+instance NFData a => NFData (Neg a) where
+  rnf (Pos a) = rnf a
+  rnf (Neg a) = rnf a
 
 -- | Class to represent invertible values.
 --


### PR DESCRIPTION
Using the philosophy of "the spirit of PVP but not the letter of the law", I explicitly omitted an upper bound for deepseq, which means: "Given what I know about the deepseq library, I believe this code will continue to work for all conceivable future versions of deepseq, even after major version bumps." If you want to follow the letter of the law, add an upper bound of `< 2` or `< 1.5`. Or let me know and I'll be happy to do it.