### PR TITLE
Support GHC 8.4

### DIFF
--- a/boolean-normal-forms.cabal
+++ b/boolean-normal-forms.cabal
@@ -17,7 +17,9 @@ tested-with:
   GHC==7.8.4,
   GHC==7.10.3,
   GHC==8.0.2,
-  GHC==8.2.2
+  GHC==8.2.2,
+  GHC==8.4.3,
+  GHC==8.6.1
 
 library
   hs-source-dirs:      src
@@ -39,8 +41,8 @@ library
                        ConstraintKinds,
                        TypeFamilies,
                        ScopedTypeVariables
-  build-depends:       base        >=4.6   && <4.12,
-                       containers  >=0.5   && <0.6,
+  build-depends:       base        >=4.6   && <4.13,
+                       containers  >=0.5   && <0.7,
                        cond        >=0.4.1 && <0.5,
                        deepseq     >=1.1.0.0 && <1.5
   default-language:    Haskell2010

--- a/boolean-normal-forms.cabal
+++ b/boolean-normal-forms.cabal
@@ -39,7 +39,7 @@ library
                        ConstraintKinds,
                        TypeFamilies,
                        ScopedTypeVariables
-  build-depends:       base        >=4.6   && <4.11,
+  build-depends:       base        >=4.6   && <4.12,
                        containers  >=0.5   && <0.6,
                        cond        >=0.4.1 && <0.5,
                        deepseq     >=1.1.0.0 && <1.5

--- a/src/Data/Algebra/Boolean/CNF/List.hs
+++ b/src/Data/Algebra/Boolean/CNF/List.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE CPP #-}
 --------------------------------------------------------------------
 -- |
 -- Copyright :  © Oleg Grenrus 2014
@@ -20,7 +21,11 @@ module Data.Algebra.Boolean.CNF.List (
   ) where
 
 import Prelude hiding ((||),(&&),not,any,all,and,or)
+
+#if !MIN_VERSION_base(4,11,0)
 import Data.Monoid
+#endif
+
 import Data.Either (partitionEithers)
 import Data.Typeable (Typeable)
 import Data.Foldable (Foldable)

--- a/src/Data/Algebra/Boolean/CNF/Set.hs
+++ b/src/Data/Algebra/Boolean/CNF/Set.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE CPP #-}
 --------------------------------------------------------------------
 -- |
 -- Copyright :  © Oleg Grenrus 2014
@@ -19,7 +20,11 @@ module Data.Algebra.Boolean.CNF.Set (
   ) where
 
 import Prelude hiding ((||),(&&),not,and,or,any,all)
+
+#if !MIN_VERSION_base(4,11,0)
 import Data.Monoid
+#endif
+
 import Data.Typeable (Typeable)
 import Data.Foldable (Foldable)
 import Control.DeepSeq (NFData(rnf))

--- a/src/Data/Algebra/Boolean/DNF/List.hs
+++ b/src/Data/Algebra/Boolean/DNF/List.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE CPP #-}
 --------------------------------------------------------------------
 -- |
 -- Copyright :  © Oleg Grenrus 2014
@@ -20,7 +21,11 @@ module Data.Algebra.Boolean.DNF.List (
   ) where
 
 import Prelude hiding ((||),(&&),not,any,all,and,or)
+
+#if !MIN_VERSION_base(4,11,0)
 import Data.Monoid
+#endif
+
 import Data.Either (partitionEithers)
 import Data.Typeable (Typeable)
 import Data.Foldable (Foldable)

--- a/src/Data/Algebra/Boolean/DNF/Set.hs
+++ b/src/Data/Algebra/Boolean/DNF/Set.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE CPP #-}
 --------------------------------------------------------------------
 -- |
 -- Copyright :  © Oleg Grenrus 2014
@@ -19,7 +20,11 @@ module Data.Algebra.Boolean.DNF.Set (
   ) where
 
 import Prelude hiding ((||),(&&),not,and,or,any,all)
+
+#if !MIN_VERSION_base(4,11,0)
 import Data.Monoid
+#endif
+
 import Data.Typeable (Typeable)
 import Data.Foldable (Foldable)
 import Control.DeepSeq (NFData(rnf))


### PR DESCRIPTION
We only needed to do the following to support GHC 8.4:

* Bump the upper bound for base.
* To avoid warnings, wrap `import Monoid` in CPP in a few modules.