### PR TITLE
Remove unlawful instance

### DIFF
--- a/src/Data/Algebra/Boolean/Negable.hs
+++ b/src/Data/Algebra/Boolean/Negable.hs
@@ -60,10 +60,6 @@ instance Negable (Neg a) where
 instance Negable Bool where
   not = P.not
 
-instance Monoid m => Negable (Maybe m) where
-  not (Just _)  = Nothing
-  not Nothing   = Just mempty
-
 instance (Negable a, Negable b) => Negable (a, b) where
   not (x, y) = (not x, not y)
 


### PR DESCRIPTION
Line 48 of Data.Algebra.Boolean.Negable says that instances "must obey the double negation law: `not (not x) = x`". The provided instance for `Maybe` does not: if `x != mempty` then

    not (not (Just x)) = not Nothing = Just mempty

It is possible to give some lawful instances involving Maybe, like

    instance Negable (Maybe ())

but it is not clear that any of them are suitably canonical or suitably interesting.